### PR TITLE
Add GitHub token secret to ros2-build-test workflow

### DIFF
--- a/.github/workflows/ros2-build-test.yaml
+++ b/.github/workflows/ros2-build-test.yaml
@@ -9,3 +9,5 @@ jobs:
     uses: catie-aq/generic_workflows/.github/workflows/pre-commit.yaml@main
   ros2-build-test:
     uses: catie-aq/ros_workflows/.github/workflows/ros2.yml@main
+    secrets:
+      PAT: ${{ secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Include the GitHub token secret in the ros2-build-test workflow to enable secure access to GitHub resources.