### PR TITLE
Refactor lidar references in URDF and RViz files

### DIFF
--- a/minipock_description/urdf/minipock.urdf.xacro
+++ b/minipock_description/urdf/minipock.urdf.xacro
@@ -34,7 +34,7 @@
 
   <!-- sensors -->
   <xacro:include filename="$(find minipock_description)/urdf/sensors.xacro" />
-  <xacro:lds_01 namespace="${namespace}" name="lds_01" x="0.0" y="0.0" z="0.050" R="${pi}" P="0.0"
+  <xacro:lidar namespace="${namespace}" name="lidar" x="0.0" y="0.0" z="0.050" R="${pi}" P="0.0"
     Y="0.0" />
 
   <gazebo>

--- a/minipock_description/urdf/minipock_base.xacro
+++ b/minipock_description/urdf/minipock_base.xacro
@@ -13,7 +13,7 @@
       <collision>
         <origin xyz="0 0 -${0.089/2}" rpy="0 -0 ${-pi/2}" />
         <geometry>
-          <cylinder radius="0.15" length="0.092" />
+          <cylinder radius="0.15" length="0.098" />
         </geometry>
       </collision>
       <inertial>

--- a/minipock_description/urdf/sensors.xacro
+++ b/minipock_description/urdf/sensors.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="minipock" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="lds_01"
-              params="namespace:=minipock/ name:=lds_01 x:=0.0 y:=0.0 z:=0.0 R:=0.0 P:=0.0 Y:=0.0">
+  <xacro:macro name="lidar"
+              params="namespace:=minipock/ name:=lidar x:=0.0 y:=0.0 z:=0.0 R:=0.0 P:=0.0 Y:=0.0">
     <link name="${namespace}${name}_link">
       <visual name="${name}_visual">
         <origin xyz="0 0 0" rpy="${pi/2} ${pi} 0"/>
@@ -28,7 +28,7 @@
       <child link="${namespace}${name}_link"/>
     </joint>
     <gazebo reference="${namespace}${name}_link">
-      <sensor type="gpu_lidar" name="lds_01">
+      <sensor type="gpu_lidar" name="lidar">
         <update_rate>10</update_rate>
         <topic>${namespace}scan_raw</topic>
         <visualize>true</visualize>

--- a/minipock_gz/minipock_gz/lidar_process.py
+++ b/minipock_gz/minipock_gz/lidar_process.py
@@ -33,12 +33,12 @@ class ScanFilterNode(Node):
     def listener_callback(self, msg):
         """
         This listener_callback method is used to process the received LaserScan message.
-        It updates the frame_id of the message to 'lds_01_link' and publishes it using a publisher.
+        It updates the frame_id of the message to 'lidar_link' and publishes it using a publisher.
 
         :param msg: The LaserScan message received from the listener.
         :return: None
         """
-        msg.header.frame_id = self.robot_name + "lds_01_link"
+        msg.header.frame_id = self.robot_name + "lidar_link"
         self.publisher.publish(msg)
 
 

--- a/minipock_navigation/minipock_cartographer/rviz/cartographer.rviz
+++ b/minipock_navigation/minipock_cartographer/rviz/cartographer.rviz
@@ -60,7 +60,7 @@ Visualization Manager:
           Value: true
         minipock_0/base_link:
           Value: true
-        minipock_0/lds_01_link:
+        minipock_0/lidar_link:
           Value: true
         minipock_0/minipock_structure_misc_link:
           Value: true
@@ -88,7 +88,7 @@ Visualization Manager:
           minipock_0/odom:
             minipock_0/base_footprint:
               minipock_0/base_link:
-                minipock_0/lds_01_link:
+                minipock_0/lidar_link:
                   {}
                 minipock_0/minipock_structure_misc_link:
                   {}

--- a/minipock_navigation/minipock_navigation2/rviz/navigation2.rviz
+++ b/minipock_navigation/minipock_navigation2/rviz/navigation2.rviz
@@ -118,7 +118,7 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        minipock_0/lds_01_link:
+        minipock_0/lidar_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false

--- a/minipock_navigation/minipock_navigation2/rviz/two_minipock.rviz
+++ b/minipock_navigation/minipock_navigation2/rviz/two_minipock.rviz
@@ -116,7 +116,7 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        minipock_0/lds_01_link:
+        minipock_0/lidar_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -428,7 +428,7 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        minipock_1/lds_01_link:
+        minipock_1/lidar_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false


### PR DESCRIPTION
This pull request standardizes the naming of the lidar sensor throughout the codebase, changing references from `lds_01` to `lidar`. This affects the URDF/Xacro sensor macro, sensor naming in Gazebo, frame IDs in the lidar processing script, and all related RViz visualization configurations. Additionally, there is a minor adjustment to the collision geometry of the robot base.

**Sensor naming standardization:**

* Renamed the lidar sensor macro from `lds_01` to `lidar` in `sensors.xacro`, updated all usages in `minipock.urdf.xacro`, and changed the sensor name in Gazebo configuration. [[1]](diffhunk://#diff-3b84b69d3b9018ab8d509a0759909001d3e8ca891b85b72cb53a625c00b42d2bL3-R4) [[2]](diffhunk://#diff-f609fd27ec8947c41e9bf98d9663b678c59c3abd42a861ef8140119a092472e5L37-R37) [[3]](diffhunk://#diff-3b84b69d3b9018ab8d509a0759909001d3e8ca891b85b72cb53a625c00b42d2bL31-R31)
* Updated frame ID references from `lds_01_link` to `lidar_link` in the lidar processing script (`lidar_process.py`) and in all RViz visualization configuration files. [[1]](diffhunk://#diff-8129af050d3785f74d393d7d971399fa6aad896ffe22bf54d4237c16df25bc4aL36-R41) [[2]](diffhunk://#diff-a07bede4f12aa0f73dfd3397b50fb4ff9188e716d21fa56fbc095ef95c9b7d19L63-R63) [[3]](diffhunk://#diff-a07bede4f12aa0f73dfd3397b50fb4ff9188e716d21fa56fbc095ef95c9b7d19L91-R91) [[4]](diffhunk://#diff-d364ea84fe90134340b34519fdd256d1aa3b46b8fd496ead368c1b81a6e0d608L121-R121) [[5]](diffhunk://#diff-ed87008199a9ecf2df20dcf6b73348c0d87310e6d61ad7c2f21f6d988d8a2920L119-R119) [[6]](diffhunk://#diff-ed87008199a9ecf2df20dcf6b73348c0d87310e6d61ad7c2f21f6d988d8a2920L431-R431)

**Robot base geometry update:**

* Increased the collision cylinder length in `minipock_base.xacro` from 0.092 to 0.098 for improved accuracy.